### PR TITLE
Fix: java.lang.ClassCastException when source `obj` is (X)HTML.

### DIFF
--- a/src/html_to_md/transformer.clj
+++ b/src/html_to_md/transformer.clj
@@ -93,6 +93,4 @@
         (if url (transform url dispatcher)
             ;; otherwise, if s is not a URL, consider it as an HTML fragment,
             ;; parse and process it
-            (process (tagsoup/parser (java.io.StringReader s)) dispatcher)
-            )))
-
+            (process (tagsoup/parser (java.io.StringReader. s)) dispatcher))))

--- a/test/html_to_md/transformer_test.clj
+++ b/test/html_to_md/transformer_test.clj
@@ -1,6 +1,5 @@
 (ns html-to-md.transformer-test
   (:require
-   [clojure.string :as str]
    [clojure.test :as t :refer [deftest is testing]]
    [html-to-md.html-to-md :refer [markdown-dispatcher]]
    [html-to-md.transformer :refer [transform]]))

--- a/test/html_to_md/transformer_test.clj
+++ b/test/html_to_md/transformer_test.clj
@@ -1,0 +1,13 @@
+(ns html-to-md.transformer-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :as t :refer [deftest is testing]]
+   [html-to-md.html-to-md :refer [markdown-dispatcher]]
+   [html-to-md.transformer :refer [transform]]))
+
+(deftest transform-payload
+  (testing "String `obj` for: 3. A string representation of an (X)HTML fragment;"
+    (is (= "# This is a header"
+           (str/trim (-> "<h1>This is a header"
+                         (transform markdown-dispatcher)
+                         (first)))))))

--- a/test/html_to_md/transformer_test.clj
+++ b/test/html_to_md/transformer_test.clj
@@ -7,7 +7,5 @@
 
 (deftest transform-payload
   (testing "String `obj` for: 3. A string representation of an (X)HTML fragment;"
-    (is (= "# This is a header"
-           (str/trim (-> "<h1>This is a header"
-                         (transform markdown-dispatcher)
-                         (first)))))))
+    (is (= '("\n# This is a header\n")
+           (transform "<h1>This is a header</h1>" markdown-dispatcher)))))


### PR DESCRIPTION
The `java.lang.ClassCastException` was caused by incorrect use of the constructor for `java.io.StringReader`.